### PR TITLE
isElementAbsent was failing because of ValidElementChain, which check…

### DIFF
--- a/src/main/java/core/namespaces/DataFactoryFunctions.java
+++ b/src/main/java/core/namespaces/DataFactoryFunctions.java
@@ -58,8 +58,8 @@ public interface DataFactoryFunctions {
         return getWithNameAndMessage(object, false, nameof, message);
     }
 
-    static Data<Boolean> getInvalidBooleanWithNameAndMessage(boolean object, String nameof, String message) {
-        return getWithNameAndMessage(object, false, nameof, message);
+    static Data<Boolean> getInvalidBooleanWithNameAndMessage(String nameof, String message) {
+        return getWithNameAndMessage(false, false, nameof, message);
     }
 
     static <T> Data<T> getWithMessage(T object, boolean status, String nameof, String message, Exception exception, String exceptionMessage) {

--- a/src/main/java/selenium/namespaces/Driver.java
+++ b/src/main/java/selenium/namespaces/Driver.java
@@ -532,7 +532,7 @@ public interface Driver {
         final var nameof = isNotBlank(name) ? name : "isElementCondition";
         final var errorMessage = isNullMessage(inverter, "Inverter");
         if (isNotBlank(errorMessage)) {
-            return DataFactoryFunctions.getInvalidBooleanWithNameAndMessage(false, nameof, errorMessage);
+            return DataFactoryFunctions.getInvalidBooleanWithNameAndMessage(nameof, errorMessage);
         }
 
         final var status = isNotNullWebElement(data);
@@ -578,11 +578,16 @@ public interface Driver {
     }
 
     static DriverFunction<Boolean> isElementAbsent(LazyElement element) {
-        return ifDriver(
-            "isElementAbsent",
-            isNotNullLazyElement(element),
-            isElementCondition(element.name, element.get(), CardinalitiesFunctions::invertBoolean, Strings.ABSENT, Strings.OPTION_NOT),
-            CoreDataConstants.NULL_BOOLEAN
+        final var nameof = "isElementAbsent";
+        final var errorMessage = isNullLazyElementMessage(element);
+        if (isNotBlank(errorMessage)) {
+            return driver -> DataFactoryFunctions.getInvalidBooleanWithNameAndMessage(nameof, errorMessage);
+        }
+
+        final var negative = CoreDataConstants.NULL_BOOLEAN;
+        return DriverFunctionFactoryFunctions.replaceName(
+            conditionalChain(NullableFunctions::isNotNull, element.get(), isElementCondition(element.name, CardinalitiesFunctions::invertBoolean, Strings.ABSENT, Strings.OPTION_NOT), negative),
+            nameof
         );
     }
 


### PR DESCRIPTION
…ed truthyness as well. For all intended purposes that is correct. Absent now uses isNotNull.